### PR TITLE
Fix Follow flow | Intercanister fix inconsistency 

### DIFF
--- a/canisters/hobbi.mo
+++ b/canisters/hobbi.mo
@@ -100,8 +100,12 @@ shared ({caller = DEPLOYER_HOBBI}) actor class Hobbi() = Hobbi  {
 
   ////////////////////////////////////////////    Funciones privadas      /////////////////////////////////////////
 
-    public query func isUserActorClass(p: CanisterID):async Bool {
+    func _isUserActorClass(p: Principal): Bool {
         Map.has<UserClassCanisterId, Principal>(principalByCID, phash, p);
+    };
+
+    public query func isUserActorClass(p: CanisterID):async Bool {
+        _isUserActorClass(p);
     };
 
     func isUser(p: Principal): Bool{
@@ -366,7 +370,8 @@ shared ({caller = DEPLOYER_HOBBI}) actor class Hobbi() = Hobbi  {
     };
  
     public shared query ({ caller }) func getUserCanisterId(u: Principal): async ?Principal {
-        assert(isAdmin(caller) or Map.has<Principal, Profile>(users, phash, u));
+        // assert(isAdmin(caller) or Map.has<Principal, Profile>(users, phash, u));
+        assert(isAdmin(caller) or _isUserActorClass(caller));
         getUserCanisterIdByPrincipal(u)
     };
 

--- a/canisters/hobbi.mo
+++ b/canisters/hobbi.mo
@@ -370,7 +370,6 @@ shared ({caller = DEPLOYER_HOBBI}) actor class Hobbi() = Hobbi  {
     };
  
     public shared query ({ caller }) func getUserCanisterId(u: Principal): async ?Principal {
-        // assert(isAdmin(caller) or Map.has<Principal, Profile>(users, phash, u));
         assert(isAdmin(caller) or _isUserActorClass(caller));
         getUserCanisterIdByPrincipal(u)
     };

--- a/canisters/hobbi.mo
+++ b/canisters/hobbi.mo
@@ -348,25 +348,26 @@ shared ({caller = DEPLOYER_HOBBI}) actor class Hobbi() = Hobbi  {
     
   ////////////////////////////////////////    Getters functions       /////////////////////////////////////////////
 
-    public shared query ({ caller }) func getMyCanisterId(): async Text{
-        let user = Map.get<Principal, Profile>(users, phash, caller);
-        switch user {
-            case null {""};
-            case (?user){
-                Principal.toText(Principal.fromActor(user.actorClass));
-            }
-        }
-    };
-
-    public shared query ({ caller }) func getUserCanisterIdByOwner(u: Principal): async ?Principal {
-        assert(isAdmin(caller));
-        let user = Map.get<Principal, Profile>(users, phash, u);
-        switch user {
+    func getUserCanisterIdByPrincipal(p: Principal): ?Principal {
+        switch (Map.get<Principal, Profile>(users, phash, p)) {
             case null { null };
             case (?user) {
                 ?Principal.fromActor(user.actorClass)
             }
         } 
+    };
+
+    public shared query ({ caller }) func getMyCanisterId(): async Text{
+        let user = getUserCanisterIdByPrincipal(caller);
+        switch user {
+            case null {""};
+            case (?cid){Principal.toText(cid)}
+        }
+    };
+ 
+    public shared query ({ caller }) func getUserCanisterId(u: Principal): async ?Principal {
+        assert(isAdmin(caller) or Map.has<Principal, Profile>(users, phash, u));
+        getUserCanisterIdByPrincipal(u)
     };
 
     public shared query ({ caller }) func gerUserCanisterIdsForUpdate(): async [Principal] {

--- a/scripts-sh/deploy-with-content.sh
+++ b/scripts-sh/deploy-with-content.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 dfx identity new 0000TestUser0
 dfx identity use 0000TestUser0
-dfx deploy hobbi
+dfx deploy --with-cycles 80TC hobbi
 
 # Usuario Peter Capusoto
 dfx identity new 0000TestUser1


### PR DESCRIPTION
The getUserCanisterId method, called from a User Actor Class through the reference to the Hobbi actor, was defined in the Hobbi canister with another name